### PR TITLE
fix: tart backend stops VM to early

### DIFF
--- a/pkg/tart/vm_darwin.go
+++ b/pkg/tart/vm_darwin.go
@@ -101,7 +101,8 @@ func (vm *VM) Start(ctx context.Context, config Config, _ *Env, customDirectoryM
 
 	runArgs = append(runArgs, vm.id)
 
-	cmd := exec.CommandContext(ctx, tartCommandName, runArgs...)
+	// Use Background context, because we want to keep the VM running
+	cmd := exec.CommandContext(context.Background(), tartCommandName, runArgs...)
 
 	common.Logger(ctx).Debug(strings.Join(runArgs, " "))
 


### PR DESCRIPTION
* the support graceful cancelling broke this incorrectly written backend