### PR TITLE
fix: use moby/go-archive due to deprecation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/distribution/reference v0.6.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
+	github.com/moby/go-archive v0.1.0
 	golang.org/x/crypto v0.37.0
 	google.golang.org/protobuf v1.36.6
 )
@@ -74,7 +75,6 @@ require (
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
-	github.com/moby/go-archive v0.1.0 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect

--- a/pkg/container/docker_build.go
+++ b/pkg/container/docker_build.go
@@ -9,9 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/pkg/archive"
-
-	// github.com/docker/docker/builder/dockerignore is deprecated
+	"github.com/moby/go-archive"
 
 	"github.com/moby/patternmatcher"
 	"github.com/moby/patternmatcher/ignorefile"


### PR DESCRIPTION
* fix further deprecation lint errors after moby/moby upgrade